### PR TITLE
Add new kernel and ruby testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+DEFAULT_TEST_VM = "kernel-3.10-ruby-2.2"
+
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList['test/**/*_test.rb']
@@ -10,7 +12,7 @@ end
 desc "Bring up Vagrant VM for testing"
 task "vagrant:up" do
   # `unset` call due to https://github.com/mitchellh/vagrant/issues/3193
-  system("unset RUBYLIB RUBYOPT; vagrant up")
+  system("unset RUBYLIB RUBYOPT; vagrant up #{DEFAULT_TEST_VM}")
 end
 
 
@@ -20,6 +22,6 @@ task :default do
   else
     Rake::Task['vagrant:up'].invoke
     # `unset` call due to https://github.com/mitchellh/vagrant/issues/3193
-    system("unset RUBYLIB RUBYOPT; vagrant ssh -c 'cd /vagrant && bundle && rake test'")
+    system("unset RUBYLIB RUBYOPT; vagrant ssh #{DEFAULT_TEST_VM} -c 'cd /vagrant && bundle && rake test'")
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
-DEFAULT_RUBY = "2.0.0-p451"
+DEFAULT_RUBY = "2.2.0"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "chef/centos-6.5"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,25 +3,51 @@
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
-DEFAULT_RUBY = "2.2.0"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/centos-6.5"
-  config.vm.box_url = "https://vagrantcloud.com/chef/centos-6.5/version/1/provider/virtualbox.box"
+  rbenv_setup = lambda do |ruby_version|
+    <<-RBENV
+      sudo -u vagrant git clone https://github.com/sstephenson/rbenv.git ~vagrant/.rbenv
+      sudo -u vagrant echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~vagrant/.bash_profile
+      sudo -u vagrant echo 'eval "$(rbenv init -)"' >> ~vagrant/.bash_profile
+      sudo -u vagrant git clone https://github.com/sstephenson/ruby-build.git ~vagrant/.rbenv/plugins/ruby-build
+      sudo -u vagrant -i rbenv install #{ruby_version}
+      sudo -u vagrant -i rbenv global #{ruby_version}
+      sudo -u vagrant -i gem install bundler
+    RBENV
+  end
 
-  config.vm.provision "shell", inline: <<-PROVISIONER
-    yum update -y
-    wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
-    wget http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
-    rpm -Uvh remi-release-6*.rpm epel-release-6*.rpm
-    yum install git libffi-devel openssl-devel readline-devel -y
-    yum groupinstall "Development Tools" -y
-    sudo -u vagrant git clone https://github.com/sstephenson/rbenv.git ~vagrant/.rbenv
-    sudo -u vagrant echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~vagrant/.bash_profile
-    sudo -u vagrant echo 'eval "$(rbenv init -)"' >> ~vagrant/.bash_profile
-    sudo -u vagrant git clone https://github.com/sstephenson/ruby-build.git ~vagrant/.rbenv/plugins/ruby-build
-    sudo -u vagrant -i rbenv install #{DEFAULT_RUBY}
-    sudo -u vagrant -i rbenv global #{DEFAULT_RUBY}
-    sudo -u vagrant -i gem install bundler
-  PROVISIONER
+  config.vm.define "kernel-2.6-ruby-2.0" do |conf|
+    ruby_version = "2.0.0-p451"
+
+    conf.vm.box = "nrel/CentOS-6.5-x86_64"
+    conf.vm.box_url = "https://vagrantcloud.com/nrel/boxes/CentOS-6.5-x86_64/versions/1.2.0/providers/virtualbox.box"
+
+    conf.vm.provision "shell", inline: <<-PROVISIONER
+      yum update -y
+      wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+      wget http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+      rpm -Uvh remi-release-6*.rpm epel-release-6*.rpm
+      yum install git libffi-devel openssl-devel readline-devel -y
+      yum groupinstall "Development Tools" -y
+      #{rbenv_setup[ruby_version]}
+    PROVISIONER
+  end
+
+  config.vm.define "kernel-3.10-ruby-2.2" do |conf|
+    ruby_version = "2.2.0"
+
+    conf.vm.box = "chef/centos-7.0"
+    conf.vm.box_url = "https://atlas.hashicorp.com/chef/boxes/centos-7.0/versions/1.0.0/providers/virtualbox.box"
+
+    conf.vm.provision "shell", inline: <<-PROVISIONER
+      yum update -y
+      wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+      wget http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
+      rpm -Uvh remi-release-7*.rpm epel-release-7*.rpm
+      yum groupinstall "Development Tools" -y
+      yum install git libffi-devel openssl-devel readline-devel -y
+      #{rbenv_setup[ruby_version]}
+    PROVISIONER
+  end
 end


### PR DESCRIPTION
Update Vagrant config to allow testing under Ruby 2.2.0/Linux 3.10

This updates the Vagrant config to allow for testing under Ruby 2.2.0
and Linux kernel 3.10. The old Vagrantfile config is still in place,
testing can be done against an earlier Ruby and kernel version by
manually switching over which VM is used in the Rakefile, since it's
not quite worth automating this yet.

The Vagrantfile was also updated to use the nrel CentOS 6.5 box, since
the Chef provided one doesn't seem to be working with the VirtualBox
guest additions any longer.