### PR TITLE
Allow for user-defined libraries

### DIFF
--- a/lib/key_control.rb
+++ b/lib/key_control.rb
@@ -25,6 +25,14 @@ module KeyControl
   def self.library_names
     LIBRARIES
   end
+  
+  # Public: Update the shared library names, for systems with different
+  # libraries that CentOS installations.
+  # 
+  # Returns an Array
+  def self.library_names=(user_libs)
+    LIBRARIES.replace Array(user_libs)
+  end
 
   # Public: Is a libkeyutils shared library detected on this system?
   #


### PR DESCRIPTION
Create a mutator for `LIBRARIES` for cases where `keyutil` library names are not CentOS default.

I needed this for two use cases:
1. On systems where I had my own build of the library and didn't want to namespace collide with the default libraries.
2. In `jruby` it didn't seem to raise the same exception, but rather a `LoadError` which would terminate the process early.

There is an edge case for systems that don't have it named in the same way as CentOS (which I couldn't find, although I didn't try too hard), if the calling application checks the ELF header of `keyctl` and identifies the correct library, it can then call `key_control` with that library.